### PR TITLE
Fix yml parsing error

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,3 +1,3 @@
 repository:  
   name:  Learning-CPlusPlus-By-Reading-PPP2E
-  description:  Documentation of my experiences learning to program in C++ by reading Bjarne Stroustrup's 'Programming: Principles and Practice Using C++,' Second Edition.  
+  description: "Documentation of my experiences learning to program in C++ by reading Bjarne Stroustrup's 'Programming: Principles and Practice Using C++,' Second Edition."


### PR DESCRIPTION
In #1 @RandomDSdevel said:

> No wonder the changes I was making to config.yml weren't taking effect…

Actually, it looks like you're being bitten by this issue: https://github.com/probot/settings/issues/38

```
YAMLException: incomplete explicit mapping pair; a key node is missed at line 3, column 119:
     ... Bjarne Stroustrup's 'Programming: Principles and Practice Using  ... 
```

Since the description has a colon in it, yaml breaks. This fixes it by surrounding the description in double quotes.

